### PR TITLE
API method extracted to an interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,43 +68,43 @@ This package uses the [gorilla mux package](http://www.gorillatoolkit.org/pkg/mu
 
 Put this code into a `main.go` file:
 
-	package main
+		package main
 
-	import (
-		"github.com/gorilla/mux"
-		"github.com/sauerbraten/crudapi"
-		"log"
-		"net/http"
-	)
+		import (
+			"github.com/gorilla/mux"
+			"github.com/sauerbraten/crudapi"
+			"log"
+			"net/http"
+		)
 
-	func hello(resp http.ResponseWriter, req *http.Request) {
-		resp.Write([]byte("Hello there!"))
-	}
-
-	func main() {
-		// storage
-		s := crudapi.NewMapStorage()
-		s.AddMap("artists")
-		s.AddMap("albums")
-
-		// router
-		r := mux.NewRouter()
-
-		// mounting the API
-		crudapi.MountAPI(r.Host("api.localhost").PathPrefix("/v1").Subrouter(), s)
-
-		// custom handler
-		r.HandleFunc("/", hello)
-
-		// start listening
-		log.Println("server listening on localhost:8080")
-		log.Println("API on api.localhost:8080/v1/")
-
-		err := http.ListenAndServe(":8080", r)
-		if err != nil {
-			log.Println(err)
+		func hello(resp http.ResponseWriter, req *http.Request) {
+			resp.Write([]byte("Hello there!"))
 		}
-	}
+
+		func main() {
+			// storage
+		  store := crudapi.NewMapStorage()
+		  store.AddMap("artists")
+		  store.AddMap("albums")
+
+			// router
+			r := mux.NewRouter()
+
+			// mounting the API
+			crudapi.MountAPI(r.Host(HOST_NAME).PathPrefix(API_PREFIX).Subrouter(), api)
+
+			// custom handler
+			r.HandleFunc("/", hello)
+
+			// start listening
+			log.Println("server listening on localhost:8080")
+			log.Println("API on api.localhost:8080/v1/")
+
+			err := http.ListenAndServe(":8080", r)
+			if err != nil {
+				log.Println(err)
+			}
+		}
 
 When the server is running, check out the [index page](http://localhost:8080/) and try the following commands in a terminal:
 

--- a/api.go
+++ b/api.go
@@ -23,12 +23,12 @@ type apiResponse struct {
 func crudUnmarshall(resp http.ResponseWriter, req *http.Request) (vars map[string]string, enc *json.Encoder, dec *json.Decoder) {
 	vars = mux.Vars(req)
 	dec = json.NewDecoder(req.Body)
+	enc = json.NewEncoder(resp)
 	return
 }
 
 func crudMarshall(resp http.ResponseWriter, respCode int, apiResp apiResponse, enc *json.Encoder) {
 	resp.WriteHeader(respCode)
-	enc = json.NewEncoder(resp)
 	err := enc.Encode(apiResp)
 	if err != nil {
 		log.Println(err)

--- a/api.go
+++ b/api.go
@@ -8,7 +8,10 @@ An example can be found at: https://github.com/sauerbraten/crudapi#example
 package crudapi
 
 import (
+	"encoding/json"
 	"github.com/gorilla/mux"
+	"log"
+	"net/http"
 )
 
 type apiResponse struct {
@@ -17,22 +20,50 @@ type apiResponse struct {
 	Result interface{} `json:"result,omitempty"`
 }
 
+func crudUnmarshall(resp http.ResponseWriter, req *http.Request) (vars map[string]string, enc *json.Encoder, dec *json.Decoder) {
+	vars = mux.Vars(req)
+	dec = json.NewDecoder(req.Body)
+	return
+}
+
+func crudMarshall(resp http.ResponseWriter, respCode int, apiResp apiResponse, enc *json.Encoder) {
+	resp.WriteHeader(respCode)
+	enc = json.NewEncoder(resp)
+	err := enc.Encode(apiResp)
+	if err != nil {
+		log.Println(err)
+	}
+	return
+}
+
+func crudCall(crudMethod func(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)) (httpMethod func(resp http.ResponseWriter, req *http.Request)) {
+	httpMethod = func(resp http.ResponseWriter, req *http.Request) {
+		//read request
+		vars, enc, dec := crudUnmarshall(resp, req)
+		//perform the action
+		respCode, apiResp := crudMethod(vars, dec)
+		//write response
+		crudMarshall(resp, respCode, apiResp, enc)
+	}
+	return
+}
+
 // Adds CRUD and OPTIONS routes to the router, which rely on the given Storage.
 func MountAPI(router *mux.Router, api ApiMethods) {
 
 	// Create
-	router.HandleFunc("/{kind}", api.CrudCall(api.CreateOne)).Methods("POST")
+	router.HandleFunc("/{kind}", crudCall(api.CreateOne)).Methods("POST")
 
 	// Read
-	router.HandleFunc("/{kind}", api.CrudCall(api.ReadAll)).Methods("GET")
-	router.HandleFunc("/{kind}/{id}", api.CrudCall(api.ReadOne)).Methods("GET")
+	router.HandleFunc("/{kind}", crudCall(api.ReadAll)).Methods("GET")
+	router.HandleFunc("/{kind}/{id}", crudCall(api.ReadOne)).Methods("GET")
 
 	// Update
-	router.HandleFunc("/{kind}/{id}", api.CrudCall(api.UpdateOne)).Methods("PUT")
+	router.HandleFunc("/{kind}/{id}", crudCall(api.UpdateOne)).Methods("PUT")
 
 	// Delete
-	router.HandleFunc("/{kind}", api.CrudCall(api.DeleteAll)).Methods("DELETE")
-	router.HandleFunc("/{kind}/{id}", api.CrudCall(api.DeleteOne)).Methods("DELETE")
+	router.HandleFunc("/{kind}", crudCall(api.DeleteAll)).Methods("DELETE")
+	router.HandleFunc("/{kind}/{id}", crudCall(api.DeleteOne)).Methods("DELETE")
 
 	// Options routes for API discovery
 	router.HandleFunc("/{kind}", api.OptionsAll).Methods("OPTIONS")

--- a/api.go
+++ b/api.go
@@ -21,18 +21,18 @@ type apiResponse struct {
 func MountAPI(router *mux.Router, api ApiMethods) {
 
 	// Create
-	router.HandleFunc("/{kind}", api.CreateOne).Methods("POST")
+	router.HandleFunc("/{kind}", api.CrudCall(api.CreateOne)).Methods("POST")
 
 	// Read
-	router.HandleFunc("/{kind}", api.ReadAll).Methods("GET")
-	router.HandleFunc("/{kind}/{id}", api.ReadOne).Methods("GET")
+	router.HandleFunc("/{kind}", api.CrudCall(api.ReadAll)).Methods("GET")
+	router.HandleFunc("/{kind}/{id}", api.CrudCall(api.ReadOne)).Methods("GET")
 
 	// Update
-	router.HandleFunc("/{kind}/{id}", api.UpdateOne).Methods("PUT")
+	router.HandleFunc("/{kind}/{id}", api.CrudCall(api.UpdateOne)).Methods("PUT")
 
 	// Delete
-	router.HandleFunc("/{kind}", api.DeleteAll).Methods("DELETE")
-	router.HandleFunc("/{kind}/{id}", api.DeleteOne).Methods("DELETE")
+	router.HandleFunc("/{kind}", api.CrudCall(api.DeleteAll)).Methods("DELETE")
+	router.HandleFunc("/{kind}/{id}", api.CrudCall(api.DeleteOne)).Methods("DELETE")
 
 	// Options routes for API discovery
 	router.HandleFunc("/{kind}", api.OptionsAll).Methods("OPTIONS")

--- a/api.go
+++ b/api.go
@@ -20,13 +20,13 @@ type apiResponse struct {
 	Result interface{} `json:"result,omitempty"`
 }
 
-func crudUnmarshall(resp http.ResponseWriter, req *http.Request) (vars map[string]string, dec *json.Decoder) {
+func crudReadRequest(resp http.ResponseWriter, req *http.Request) (vars map[string]string, dec *json.Decoder) {
 	vars = mux.Vars(req)
 	dec = json.NewDecoder(req.Body)
 	return
 }
 
-func crudMarshall(resp http.ResponseWriter, respCode int, apiResp apiResponse) {
+func crudWriteResponse(resp http.ResponseWriter, respCode int, apiResp apiResponse) {
 	resp.WriteHeader(respCode)
 	enc := json.NewEncoder(resp)
 	err := enc.Encode(apiResp)
@@ -38,12 +38,12 @@ func crudMarshall(resp http.ResponseWriter, respCode int, apiResp apiResponse) {
 
 func crudCall(crudMethod func(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)) (httpMethod func(resp http.ResponseWriter, req *http.Request)) {
 	httpMethod = func(resp http.ResponseWriter, req *http.Request) {
-		//read request
-		vars, dec := crudUnmarshall(resp, req)
-		//perform the action
+		vars, dec := crudReadRequest(resp, req)
+
+		//perform the specific CRUD action requested
 		respCode, apiResp := crudMethod(vars, dec)
-		//write response
-		crudMarshall(resp, respCode, apiResp)
+
+		crudWriteResponse(resp, respCode, apiResp)
 	}
 	return
 }

--- a/api.go
+++ b/api.go
@@ -20,15 +20,15 @@ type apiResponse struct {
 	Result interface{} `json:"result,omitempty"`
 }
 
-func crudUnmarshall(resp http.ResponseWriter, req *http.Request) (vars map[string]string, enc *json.Encoder, dec *json.Decoder) {
+func crudUnmarshall(resp http.ResponseWriter, req *http.Request) (vars map[string]string, dec *json.Decoder) {
 	vars = mux.Vars(req)
 	dec = json.NewDecoder(req.Body)
-	enc = json.NewEncoder(resp)
 	return
 }
 
-func crudMarshall(resp http.ResponseWriter, respCode int, apiResp apiResponse, enc *json.Encoder) {
+func crudMarshall(resp http.ResponseWriter, respCode int, apiResp apiResponse) {
 	resp.WriteHeader(respCode)
+	enc := json.NewEncoder(resp)
 	err := enc.Encode(apiResp)
 	if err != nil {
 		log.Println(err)
@@ -39,11 +39,11 @@ func crudMarshall(resp http.ResponseWriter, respCode int, apiResp apiResponse, e
 func crudCall(crudMethod func(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)) (httpMethod func(resp http.ResponseWriter, req *http.Request)) {
 	httpMethod = func(resp http.ResponseWriter, req *http.Request) {
 		//read request
-		vars, enc, dec := crudUnmarshall(resp, req)
+		vars, dec := crudUnmarshall(resp, req)
 		//perform the action
 		respCode, apiResp := crudMethod(vars, dec)
 		//write response
-		crudMarshall(resp, respCode, apiResp, enc)
+		crudMarshall(resp, respCode, apiResp)
 	}
 	return
 }

--- a/api.go
+++ b/api.go
@@ -8,10 +8,7 @@ An example can be found at: https://github.com/sauerbraten/crudapi#example
 package crudapi
 
 import (
-	"encoding/json"
 	"github.com/gorilla/mux"
-	"log"
-	"net/http"
 )
 
 type apiResponse struct {
@@ -20,182 +17,24 @@ type apiResponse struct {
 	Result interface{} `json:"result,omitempty"`
 }
 
-var s Storage
-
 // Adds CRUD and OPTIONS routes to the router, which rely on the given Storage.
-func MountAPI(router *mux.Router, storage Storage) {
-	s = storage
+func MountAPI(router *mux.Router, api ApiMethods) {
 
 	// Create
-	router.HandleFunc("/{kind}", create).Methods("POST")
+	router.HandleFunc("/{kind}", api.CreateOne).Methods("POST")
 
 	// Read
-	router.HandleFunc("/{kind}", getAll).Methods("GET")
-	router.HandleFunc("/{kind}/{id}", get).Methods("GET")
+	router.HandleFunc("/{kind}", api.ReadAll).Methods("GET")
+	router.HandleFunc("/{kind}/{id}", api.ReadOne).Methods("GET")
 
 	// Update
-	router.HandleFunc("/{kind}/{id}", update).Methods("PUT")
+	router.HandleFunc("/{kind}/{id}", api.UpdateOne).Methods("PUT")
 
 	// Delete
-	router.HandleFunc("/{kind}", delAll).Methods("DELETE")
-	router.HandleFunc("/{kind}/{id}", del).Methods("DELETE")
+	router.HandleFunc("/{kind}", api.DeleteAll).Methods("DELETE")
+	router.HandleFunc("/{kind}/{id}", api.DeleteOne).Methods("DELETE")
 
-	// OPTIONS routes for API discovery
-	router.HandleFunc("/{kind}", optionsKind).Methods("OPTIONS")
-	router.HandleFunc("/{kind}/{id}", optionsId).Methods("OPTIONS")
-}
-
-func create(resp http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-	kind := vars["kind"]
-	enc := json.NewEncoder(resp)
-	dec := json.NewDecoder(req.Body)
-
-	// read body and parse into interface{}
-	var resource map[string]interface{}
-	err := dec.Decode(&resource)
-
-	if err != nil {
-		log.Println(err)
-
-		resp.WriteHeader(http.StatusBadRequest)
-		err = enc.Encode(apiResponse{"malformed json", "", nil})
-		if err != nil {
-			log.Println(err)
-		}
-
-		return
-	}
-
-	// set in storage
-	id, stoResp := s.Create(kind, resource)
-
-	// write response
-	resp.WriteHeader(stoResp.StatusCode)
-	err = enc.Encode(apiResponse{stoResp.Err, id, nil})
-	if err != nil {
-		log.Println(err)
-	}
-}
-
-func getAll(resp http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-	kind := vars["kind"]
-	enc := json.NewEncoder(resp)
-
-	// look for resources
-	resources, stoResp := s.GetAll(kind)
-
-	// write response
-	resp.WriteHeader(stoResp.StatusCode)
-	err := enc.Encode(apiResponse{stoResp.Err, "", resources})
-	if err != nil {
-		log.Println(err)
-	}
-}
-
-func get(resp http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-	kind := vars["kind"]
-	id := vars["id"]
-	enc := json.NewEncoder(resp)
-
-	// look for resource
-	resource, stoResp := s.Get(kind, id)
-
-	// write response
-	resp.WriteHeader(stoResp.StatusCode)
-	err := enc.Encode(apiResponse{stoResp.Err, "", resource})
-	if err != nil {
-		log.Println(err)
-	}
-}
-
-func update(resp http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-	kind := vars["kind"]
-	id := vars["id"]
-	enc := json.NewEncoder(resp)
-	dec := json.NewDecoder(req.Body)
-
-	// read body and parse into interface{}
-	var resource map[string]interface{}
-	err := dec.Decode(&resource)
-
-	if err != nil {
-		log.Println(err)
-		resp.WriteHeader(http.StatusBadRequest)
-		err = enc.Encode(apiResponse{"malformed json", "", nil})
-		if err != nil {
-			log.Println(err)
-		}
-
-		return
-	}
-
-	// update resource
-	stoResp := s.Update(kind, id, resource)
-
-	// write response
-	resp.WriteHeader(stoResp.StatusCode)
-	err = enc.Encode(apiResponse{stoResp.Err, "", nil})
-	if err != nil {
-		log.Println(err)
-	}
-}
-
-// delete() is a built-in function for maps, thus the shorthand name 'del' for this handler function
-func del(resp http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-	kind := vars["kind"]
-	id := vars["id"]
-	enc := json.NewEncoder(resp)
-
-	// delete resource
-	stoResp := s.Delete(kind, id)
-
-	// write response
-	resp.WriteHeader(stoResp.StatusCode)
-	err := enc.Encode(apiResponse{stoResp.Err, "", nil})
-	if err != nil {
-		log.Println(err)
-	}
-}
-
-func delAll(resp http.ResponseWriter, req *http.Request) {
-	vars := mux.Vars(req)
-	kind := vars["kind"]
-	enc := json.NewEncoder(resp)
-
-	// look for resources
-	stoResp := s.DeleteAll(kind)
-
-	// write response
-	resp.WriteHeader(stoResp.StatusCode)
-	err := enc.Encode(apiResponse{stoResp.Err, "", nil})
-	if err != nil {
-		log.Println(err)
-	}
-}
-
-func optionsKind(resp http.ResponseWriter, req *http.Request) {
-	h := resp.Header()
-
-	h.Add("Allow", "POST")
-	h.Add("Allow", "GET")
-	h.Add("Allow", "DELETE")
-	h.Add("Allow", "OPTIONS")
-
-	resp.WriteHeader(http.StatusOK)
-}
-
-func optionsId(resp http.ResponseWriter, req *http.Request) {
-	h := resp.Header()
-
-	h.Add("Allow", "PUT")
-	h.Add("Allow", "GET")
-	h.Add("Allow", "DELETE")
-	h.Add("Allow", "OPTIONS")
-
-	resp.WriteHeader(http.StatusOK)
+	// Options routes for API discovery
+	router.HandleFunc("/{kind}", api.OptionsAll).Methods("OPTIONS")
+	router.HandleFunc("/{kind}/{id}", api.OptionsOne).Methods("OPTIONS")
 }

--- a/apimethods.go
+++ b/apimethods.go
@@ -1,21 +1,20 @@
 package crudapi
 
 import (
-  "net/http"
+	"net/http"
 )
 
 type ApiMethods interface {
+	CreateOne(resp http.ResponseWriter, req *http.Request)
 
-  CreateOne(resp http.ResponseWriter, req *http.Request)
+	ReadOne(resp http.ResponseWriter, req *http.Request)
+	ReadAll(resp http.ResponseWriter, req *http.Request)
 
-  ReadOne(resp http.ResponseWriter, req *http.Request)
-  ReadAll(resp http.ResponseWriter, req *http.Request)
+	UpdateOne(resp http.ResponseWriter, req *http.Request)
 
-  UpdateOne(resp http.ResponseWriter, req *http.Request)
+	DeleteOne(resp http.ResponseWriter, req *http.Request)
+	DeleteAll(resp http.ResponseWriter, req *http.Request)
 
-  DeleteOne(resp http.ResponseWriter, req *http.Request)
-  DeleteAll(resp http.ResponseWriter, req *http.Request)
-
-  OptionsOne(resp http.ResponseWriter, req *http.Request)
-  OptionsAll(resp http.ResponseWriter, req *http.Request)
+	OptionsOne(resp http.ResponseWriter, req *http.Request)
+	OptionsAll(resp http.ResponseWriter, req *http.Request)
 }

--- a/apimethods.go
+++ b/apimethods.go
@@ -1,0 +1,21 @@
+package crudapi
+
+import (
+  "net/http"
+)
+
+type ApiMethods interface {
+
+  CreateOne(resp http.ResponseWriter, req *http.Request)
+
+  ReadOne(resp http.ResponseWriter, req *http.Request)
+  ReadAll(resp http.ResponseWriter, req *http.Request)
+
+  UpdateOne(resp http.ResponseWriter, req *http.Request)
+
+  DeleteOne(resp http.ResponseWriter, req *http.Request)
+  DeleteAll(resp http.ResponseWriter, req *http.Request)
+
+  OptionsOne(resp http.ResponseWriter, req *http.Request)
+  OptionsAll(resp http.ResponseWriter, req *http.Request)
+}

--- a/apimethods.go
+++ b/apimethods.go
@@ -6,8 +6,6 @@ import (
 )
 
 type ApiMethods interface {
-	CrudCall(crudMethod func(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)) (httpMethod func(resp http.ResponseWriter, req *http.Request))
-
 	CreateOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)
 
 	ReadOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)

--- a/apimethods.go
+++ b/apimethods.go
@@ -6,19 +6,6 @@ import (
 )
 
 type ApiMethods interface {
-	// CreateOne(resp http.ResponseWriter, req *http.Request)
-
-	// ReadOne(resp http.ResponseWriter, req *http.Request)
-	// ReadAll(resp http.ResponseWriter, req *http.Request)
-
-	// UpdateOne(resp http.ResponseWriter, req *http.Request)
-
-	// DeleteOne(resp http.ResponseWriter, req *http.Request)
-	// DeleteAll(resp http.ResponseWriter, req *http.Request)
-
-	// OptionsOne(resp http.ResponseWriter, req *http.Request)
-	// OptionsAll(resp http.ResponseWriter, req *http.Request)
-
 	CrudCall(crudMethod func(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)) (httpMethod func(resp http.ResponseWriter, req *http.Request))
 
 	CreateOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)

--- a/apimethods.go
+++ b/apimethods.go
@@ -1,19 +1,35 @@
 package crudapi
 
 import (
+	"encoding/json"
 	"net/http"
 )
 
 type ApiMethods interface {
-	CreateOne(resp http.ResponseWriter, req *http.Request)
+	// CreateOne(resp http.ResponseWriter, req *http.Request)
 
-	ReadOne(resp http.ResponseWriter, req *http.Request)
-	ReadAll(resp http.ResponseWriter, req *http.Request)
+	// ReadOne(resp http.ResponseWriter, req *http.Request)
+	// ReadAll(resp http.ResponseWriter, req *http.Request)
 
-	UpdateOne(resp http.ResponseWriter, req *http.Request)
+	// UpdateOne(resp http.ResponseWriter, req *http.Request)
 
-	DeleteOne(resp http.ResponseWriter, req *http.Request)
-	DeleteAll(resp http.ResponseWriter, req *http.Request)
+	// DeleteOne(resp http.ResponseWriter, req *http.Request)
+	// DeleteAll(resp http.ResponseWriter, req *http.Request)
+
+	// OptionsOne(resp http.ResponseWriter, req *http.Request)
+	// OptionsAll(resp http.ResponseWriter, req *http.Request)
+
+	CrudCall(crudMethod func(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)) (httpMethod func(resp http.ResponseWriter, req *http.Request))
+
+	CreateOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)
+
+	ReadOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)
+	ReadAll(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)
+
+	UpdateOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)
+
+	DeleteOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)
+	DeleteAll(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)
 
 	OptionsOne(resp http.ResponseWriter, req *http.Request)
 	OptionsAll(resp http.ResponseWriter, req *http.Request)

--- a/defaultapimethods.go
+++ b/defaultapimethods.go
@@ -6,15 +6,15 @@ import (
 	"net/http"
 )
 
-type NoAuthApiMethods struct {
+type DefaultApiMethods struct {
 	s Storage
 }
 
-func NewNoAuthApiMethods(store Storage) NoAuthApiMethods {
-	return NoAuthApiMethods{store}
+func NewDefaultApiMethods(store Storage) DefaultApiMethods {
+	return DefaultApiMethods{store}
 }
 
-func (self NoAuthApiMethods) CreateOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
+func (self DefaultApiMethods) CreateOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 
 	// read body and parse into interface{}
@@ -34,7 +34,7 @@ func (self NoAuthApiMethods) CreateOne(vars map[string]string, dec *json.Decoder
 	return
 }
 
-func (self NoAuthApiMethods) ReadOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
+func (self DefaultApiMethods) ReadOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 	id := vars["id"]
 
@@ -45,7 +45,7 @@ func (self NoAuthApiMethods) ReadOne(vars map[string]string, dec *json.Decoder) 
 	return
 }
 
-func (self NoAuthApiMethods) ReadAll(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
+func (self DefaultApiMethods) ReadAll(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 
 	// look for resources
@@ -55,7 +55,7 @@ func (self NoAuthApiMethods) ReadAll(vars map[string]string, dec *json.Decoder) 
 	return
 }
 
-func (self NoAuthApiMethods) UpdateOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
+func (self DefaultApiMethods) UpdateOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 	id := vars["id"]
 
@@ -76,7 +76,7 @@ func (self NoAuthApiMethods) UpdateOne(vars map[string]string, dec *json.Decoder
 	return
 }
 
-func (self NoAuthApiMethods) DeleteOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
+func (self DefaultApiMethods) DeleteOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 	id := vars["id"]
 
@@ -87,7 +87,7 @@ func (self NoAuthApiMethods) DeleteOne(vars map[string]string, dec *json.Decoder
 	return
 }
 
-func (self NoAuthApiMethods) DeleteAll(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
+func (self DefaultApiMethods) DeleteAll(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 
 	// look for resources
@@ -97,7 +97,7 @@ func (self NoAuthApiMethods) DeleteAll(vars map[string]string, dec *json.Decoder
 	return
 }
 
-func (self NoAuthApiMethods) OptionsOne(resp http.ResponseWriter, req *http.Request) {
+func (self DefaultApiMethods) OptionsOne(resp http.ResponseWriter, req *http.Request) {
 	h := resp.Header()
 
 	h.Add("Allow", "PUT")
@@ -108,7 +108,7 @@ func (self NoAuthApiMethods) OptionsOne(resp http.ResponseWriter, req *http.Requ
 	resp.WriteHeader(http.StatusOK)
 	return
 }
-func (self NoAuthApiMethods) OptionsAll(resp http.ResponseWriter, req *http.Request) {
+func (self DefaultApiMethods) OptionsAll(resp http.ResponseWriter, req *http.Request) {
 	h := resp.Header()
 
 	h.Add("Allow", "POST")

--- a/guard.go
+++ b/guard.go
@@ -1,0 +1,41 @@
+package crudapi
+
+import (
+	"net/url"
+)
+
+// A CRUD action. See constants for predefined actions.
+type Action string
+
+type UrlVars map[string]string
+
+const (
+	ActionCreate    Action = "create"
+	ActionGet       Action = "get"
+	ActionGetAll    Action = "get all"
+	ActionUpdate    Action = "update"
+	ActionDelete    Action = "delete"
+	ActionDeleteAll Action = "delete all"
+)
+
+// A guard authenticates users and authorizes their requests.
+type Guard interface {
+	// Tries to authenticate a client (e.g. using API keys or signed requests). Returns wether the client could be authenticated, a string which will be passed to Guard.Authorize() and should be used to set levels of permissions, or per-user-permissions, and an error message in case of an error or in case the client could not be authenticated.
+	Authenticate(params url.Values) (ok bool, client string, errorMessage string)
+
+	// Tries to authorize the action (one of the Action* constants) to be performed on the kind of resource by the client. Returns wether the action is authorized, and if not, an error message to be sent back to the client.
+	Authorize(client string, action Action, vars UrlVars) (ok bool, errorMessage string)
+}
+
+// default guard; allows everyone to do everything
+type defaultGuard struct{}
+
+func (d defaultGuard) Authenticate(params url.Values) (ok bool, client string, errorMessage string) {
+	ok = true
+	return
+}
+
+func (d defaultGuard) Authorize(client string, action Action, vars UrlVars) (ok bool, errorMessage string) {
+	ok = true
+	return
+}

--- a/noauthapimethods.go
+++ b/noauthapimethods.go
@@ -32,15 +32,26 @@ func crudMarshall(resp http.ResponseWriter, respCode int, apiResp apiResponse, e
 }
 
 func (self NoAuthApiMethods) CreateOne(resp http.ResponseWriter, req *http.Request) {
+	//read request
 	vars, enc, dec := crudUnmarshall(resp, req)
+
+	//perform the action
+	respCode, apiResp := self.CreateOnePerform(vars, dec)
+
+	//write response
+	crudMarshall(resp, respCode, apiResp, enc)
+	return
+}
+
+func (self NoAuthApiMethods) CreateOnePerform(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 
 	// read body and parse into interface{}
 	var resource map[string]interface{}
 	err := dec.Decode(&resource)
 
-	var respCode int
-	var apiResp apiResponse
+	// var respCode int
+	// var apiResp apiResponse
 	if err != nil {
 		log.Println(err)
 		respCode = http.StatusBadRequest
@@ -51,23 +62,29 @@ func (self NoAuthApiMethods) CreateOne(resp http.ResponseWriter, req *http.Reque
 		respCode = stoResp.StatusCode
 		apiResp = apiResponse{stoResp.Err, id, nil}
 	}
-
-	// write response
-	crudMarshall(resp, respCode, apiResp, enc)
 	return
 }
 
 func (self NoAuthApiMethods) ReadOne(resp http.ResponseWriter, req *http.Request) {
-	vars, enc, _ := crudUnmarshall(resp, req)
+	//read request
+	vars, enc, dec := crudUnmarshall(resp, req)
+
+	//perform the action
+	respCode, apiResp := self.ReadOnePerform(vars, dec)
+
+	//write response
+	crudMarshall(resp, respCode, apiResp, enc)
+	return
+}
+
+func (self NoAuthApiMethods) ReadOnePerform(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 	id := vars["id"]
 
 	// look for resource
 	resource, stoResp := self.s.Get(kind, id)
-	apiResp := apiResponse{stoResp.Err, "", resource}
-
-	// write response
-	crudMarshall(resp, stoResp.StatusCode, apiResp, enc)
+	respCode = stoResp.StatusCode
+	apiResp = apiResponse{stoResp.Err, "", resource}
 	return
 }
 

--- a/noauthapimethods.go
+++ b/noauthapimethods.go
@@ -43,16 +43,6 @@ func (self NoAuthApiMethods) CrudCall(crudMethod func(vars map[string]string, de
 	return
 }
 
-// func (self NoAuthApiMethods) CreateOne(resp http.ResponseWriter, req *http.Request) {
-// 	//read request
-// 	vars, enc, dec := crudUnmarshall(resp, req)
-// 	//perform the action
-// 	respCode, apiResp := self.CreateOnePerform(vars, dec)
-// 	//write response
-// 	crudMarshall(resp, respCode, apiResp, enc)
-// 	return
-// }
-
 func (self NoAuthApiMethods) CreateOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 
@@ -73,16 +63,6 @@ func (self NoAuthApiMethods) CreateOne(vars map[string]string, dec *json.Decoder
 	return
 }
 
-// func (self NoAuthApiMethods) ReadOne(resp http.ResponseWriter, req *http.Request) {
-// 	//read request
-// 	vars, enc, dec := crudUnmarshall(resp, req)
-// 	//perform the action
-// 	respCode, apiResp := self.ReadOnePerform(vars, dec)
-// 	//write response
-// 	crudMarshall(resp, respCode, apiResp, enc)
-// 	return
-// }
-
 func (self NoAuthApiMethods) ReadOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 	id := vars["id"]
@@ -94,16 +74,6 @@ func (self NoAuthApiMethods) ReadOne(vars map[string]string, dec *json.Decoder) 
 	return
 }
 
-// func (self NoAuthApiMethods) ReadAll(resp http.ResponseWriter, req *http.Request) {
-// 	//read request
-// 	vars, enc, dec := crudUnmarshall(resp, req)
-// 	//perform the action
-// 	respCode, apiResp := self.ReadAllPerform(vars, dec)
-// 	//write response
-// 	crudMarshall(resp, respCode, apiResp, enc)
-// 	return
-// }
-
 func (self NoAuthApiMethods) ReadAll(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 
@@ -113,16 +83,6 @@ func (self NoAuthApiMethods) ReadAll(vars map[string]string, dec *json.Decoder) 
 	apiResp = apiResponse{stoResp.Err, "", resources}
 	return
 }
-
-// func (self NoAuthApiMethods) UpdateOne(resp http.ResponseWriter, req *http.Request) {
-// 	//read request
-// 	vars, enc, dec := crudUnmarshall(resp, req)
-// 	//perform the action
-// 	respCode, apiResp := self.UpdateOnePerform(vars, dec)
-// 	//write response
-// 	crudMarshall(resp, respCode, apiResp, enc)
-// 	return
-// }
 
 func (self NoAuthApiMethods) UpdateOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
@@ -145,16 +105,6 @@ func (self NoAuthApiMethods) UpdateOne(vars map[string]string, dec *json.Decoder
 	return
 }
 
-// func (self NoAuthApiMethods) DeleteOne(resp http.ResponseWriter, req *http.Request) {
-// 	//read request
-// 	vars, enc, dec := crudUnmarshall(resp, req)
-// 	//perform the action
-// 	respCode, apiResp := self.DeleteOnePerform(vars, dec)
-// 	//write response
-// 	crudMarshall(resp, respCode, apiResp, enc)
-// 	return
-// }
-
 func (self NoAuthApiMethods) DeleteOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 	id := vars["id"]
@@ -165,16 +115,6 @@ func (self NoAuthApiMethods) DeleteOne(vars map[string]string, dec *json.Decoder
 	apiResp = apiResponse{stoResp.Err, "", nil}
 	return
 }
-
-// func (self NoAuthApiMethods) DeleteAll(resp http.ResponseWriter, req *http.Request) {
-// 	//read request
-// 	vars, enc, dec := crudUnmarshall(resp, req)
-// 	//perform the action
-// 	respCode, apiResp := self.DeleteAllPerform(vars, dec)
-// 	//write response
-// 	crudMarshall(resp, respCode, apiResp, enc)
-// 	return
-// }
 
 func (self NoAuthApiMethods) DeleteAll(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]

--- a/noauthapimethods.go
+++ b/noauthapimethods.go
@@ -16,29 +16,162 @@ func NewNoAuthApiMethods(store Storage) NoAuthApiMethods {
 }
 
 func (self NoAuthApiMethods) CreateOne(resp http.ResponseWriter, req *http.Request) {
+  vars := mux.Vars(req)
+  kind := vars["kind"]
+  enc := json.NewEncoder(resp)
+  dec := json.NewDecoder(req.Body)
+
+  // read body and parse into interface{}
+  var resource map[string]interface{}
+  err := dec.Decode(&resource)
+
+  if err != nil {
+   log.Println(err)
+
+   resp.WriteHeader(http.StatusBadRequest)
+   err = enc.Encode(apiResponse{"malformed json", "", nil})
+   if err != nil {
+     log.Println(err)
+   }
+
+   return
+  }
+
+  // set in storage
+  id, stoResp := self.s.Create(kind, resource)
+
+  // write response
+  resp.WriteHeader(stoResp.StatusCode)
+  err = enc.Encode(apiResponse{stoResp.Err, id, nil})
+  if err != nil {
+   log.Println(err)
+  }
+  return
 }
 
 func (self NoAuthApiMethods) ReadOne(resp http.ResponseWriter, req *http.Request) {
+  vars := mux.Vars(req)
+  kind := vars["kind"]
+  id := vars["id"]
+  enc := json.NewEncoder(resp)
+
+  // look for resource
+  resource, stoResp := self.s.Get(kind, id)
+
+  // write response
+  resp.WriteHeader(stoResp.StatusCode)
+  err := enc.Encode(apiResponse{stoResp.Err, "", resource})
+  if err != nil {
+   log.Println(err)
+  }
   return
 }
+
 func (self NoAuthApiMethods) ReadAll(resp http.ResponseWriter, req *http.Request) {
+  vars := mux.Vars(req)
+  kind := vars["kind"]
+  enc := json.NewEncoder(resp)
+
+  // look for resources
+  resources, stoResp := self.s.GetAll(kind)
+
+  // write response
+  resp.WriteHeader(stoResp.StatusCode)
+  err := enc.Encode(apiResponse{stoResp.Err, "", resources})
+  if err != nil {
+   log.Println(err)
+  }
   return
 }
 
 func (self NoAuthApiMethods) UpdateOne(resp http.ResponseWriter, req *http.Request) {
+  vars := mux.Vars(req)
+  kind := vars["kind"]
+  id := vars["id"]
+  enc := json.NewEncoder(resp)
+  dec := json.NewDecoder(req.Body)
+
+  // read body and parse into interface{}
+  var resource map[string]interface{}
+  err := dec.Decode(&resource)
+
+  if err != nil {
+   log.Println(err)
+   resp.WriteHeader(http.StatusBadRequest)
+   err = enc.Encode(apiResponse{"malformed json", "", nil})
+   if err != nil {
+     log.Println(err)
+   }
+
+   return
+  }
+
+  // update resource
+  stoResp := self.s.Update(kind, id, resource)
+
+  // write response
+  resp.WriteHeader(stoResp.StatusCode)
+  err = enc.Encode(apiResponse{stoResp.Err, "", nil})
+  if err != nil {
+   log.Println(err)
+  }
   return
 }
 
 func (self NoAuthApiMethods) DeleteOne(resp http.ResponseWriter, req *http.Request) {
+  vars := mux.Vars(req)
+  kind := vars["kind"]
+  id := vars["id"]
+  enc := json.NewEncoder(resp)
+
+  // delete resource
+  stoResp := self.s.Delete(kind, id)
+
+  // write response
+  resp.WriteHeader(stoResp.StatusCode)
+  err := enc.Encode(apiResponse{stoResp.Err, "", nil})
+  if err != nil {
+   log.Println(err)
+  }
   return
 }
+
 func (self NoAuthApiMethods) DeleteAll(resp http.ResponseWriter, req *http.Request) {
+  vars := mux.Vars(req)
+  kind := vars["kind"]
+  enc := json.NewEncoder(resp)
+
+  // look for resources
+  stoResp := self.s.DeleteAll(kind)
+
+  // write response
+  resp.WriteHeader(stoResp.StatusCode)
+  err := enc.Encode(apiResponse{stoResp.Err, "", nil})
+  if err != nil {
+   log.Println(err)
+  }
   return
 }
 
 func (self NoAuthApiMethods) OptionsOne(resp http.ResponseWriter, req *http.Request) {
+  h := resp.Header()
+
+  h.Add("Allow", "PUT")
+  h.Add("Allow", "GET")
+  h.Add("Allow", "DELETE")
+  h.Add("Allow", "OPTIONS")
+
+  resp.WriteHeader(http.StatusOK)
   return
 }
 func (self NoAuthApiMethods) OptionsAll(resp http.ResponseWriter, req *http.Request) {
+  h := resp.Header()
+
+  h.Add("Allow", "POST")
+  h.Add("Allow", "GET")
+  h.Add("Allow", "DELETE")
+  h.Add("Allow", "OPTIONS")
+
+  resp.WriteHeader(http.StatusOK)
   return
 }

--- a/noauthapimethods.go
+++ b/noauthapimethods.go
@@ -34,10 +34,8 @@ func crudMarshall(resp http.ResponseWriter, respCode int, apiResp apiResponse, e
 func (self NoAuthApiMethods) CreateOne(resp http.ResponseWriter, req *http.Request) {
 	//read request
 	vars, enc, dec := crudUnmarshall(resp, req)
-
 	//perform the action
 	respCode, apiResp := self.CreateOnePerform(vars, dec)
-
 	//write response
 	crudMarshall(resp, respCode, apiResp, enc)
 	return
@@ -50,8 +48,6 @@ func (self NoAuthApiMethods) CreateOnePerform(vars map[string]string, dec *json.
 	var resource map[string]interface{}
 	err := dec.Decode(&resource)
 
-	// var respCode int
-	// var apiResp apiResponse
 	if err != nil {
 		log.Println(err)
 		respCode = http.StatusBadRequest
@@ -68,10 +64,8 @@ func (self NoAuthApiMethods) CreateOnePerform(vars map[string]string, dec *json.
 func (self NoAuthApiMethods) ReadOne(resp http.ResponseWriter, req *http.Request) {
 	//read request
 	vars, enc, dec := crudUnmarshall(resp, req)
-
 	//perform the action
 	respCode, apiResp := self.ReadOnePerform(vars, dec)
-
 	//write response
 	crudMarshall(resp, respCode, apiResp, enc)
 	return
@@ -89,20 +83,36 @@ func (self NoAuthApiMethods) ReadOnePerform(vars map[string]string, dec *json.De
 }
 
 func (self NoAuthApiMethods) ReadAll(resp http.ResponseWriter, req *http.Request) {
-	vars, enc, _ := crudUnmarshall(resp, req)
+	//read request
+	vars, enc, dec := crudUnmarshall(resp, req)
+	//perform the action
+	respCode, apiResp := self.ReadAllPerform(vars, dec)
+	//write response
+	crudMarshall(resp, respCode, apiResp, enc)
+	return
+}
+
+func (self NoAuthApiMethods) ReadAllPerform(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 
 	// look for resources
 	resources, stoResp := self.s.GetAll(kind)
-	apiResp := apiResponse{stoResp.Err, "", resources}
-
-	// write response
-	crudMarshall(resp, stoResp.StatusCode, apiResp, enc)
+	respCode = stoResp.StatusCode
+	apiResp = apiResponse{stoResp.Err, "", resources}
 	return
 }
 
 func (self NoAuthApiMethods) UpdateOne(resp http.ResponseWriter, req *http.Request) {
+	//read request
 	vars, enc, dec := crudUnmarshall(resp, req)
+	//perform the action
+	respCode, apiResp := self.UpdateOnePerform(vars, dec)
+	//write response
+	crudMarshall(resp, respCode, apiResp, enc)
+	return
+}
+
+func (self NoAuthApiMethods) UpdateOnePerform(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 	id := vars["id"]
 
@@ -110,8 +120,6 @@ func (self NoAuthApiMethods) UpdateOne(resp http.ResponseWriter, req *http.Reque
 	var resource map[string]interface{}
 	err := dec.Decode(&resource)
 
-	var respCode int
-	var apiResp apiResponse
 	if err != nil {
 		log.Println(err)
 		respCode = http.StatusBadRequest
@@ -122,36 +130,47 @@ func (self NoAuthApiMethods) UpdateOne(resp http.ResponseWriter, req *http.Reque
 		respCode = stoResp.StatusCode
 		apiResp = apiResponse{stoResp.Err, "", nil}
 	}
-
-	// write response
-	crudMarshall(resp, respCode, apiResp, enc)
 	return
 }
 
 func (self NoAuthApiMethods) DeleteOne(resp http.ResponseWriter, req *http.Request) {
-	vars, enc, _ := crudUnmarshall(resp, req)
+	//read request
+	vars, enc, dec := crudUnmarshall(resp, req)
+	//perform the action
+	respCode, apiResp := self.DeleteOnePerform(vars, dec)
+	//write response
+	crudMarshall(resp, respCode, apiResp, enc)
+	return
+}
+
+func (self NoAuthApiMethods) DeleteOnePerform(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 	id := vars["id"]
 
 	// delete resource
 	stoResp := self.s.Delete(kind, id)
-	apiResp := apiResponse{stoResp.Err, "", nil}
-
-	// write response
-	crudMarshall(resp, stoResp.StatusCode, apiResp, enc)
+	respCode = stoResp.StatusCode
+	apiResp = apiResponse{stoResp.Err, "", nil}
 	return
 }
 
 func (self NoAuthApiMethods) DeleteAll(resp http.ResponseWriter, req *http.Request) {
-	vars, enc, _ := crudUnmarshall(resp, req)
+	//read request
+	vars, enc, dec := crudUnmarshall(resp, req)
+	//perform the action
+	respCode, apiResp := self.DeleteAllPerform(vars, dec)
+	//write response
+	crudMarshall(resp, respCode, apiResp, enc)
+	return
+}
+
+func (self NoAuthApiMethods) DeleteAllPerform(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 
 	// look for resources
 	stoResp := self.s.DeleteAll(kind)
-	apiResp := apiResponse{stoResp.Err, "", nil}
-
-	// write response
-	crudMarshall(resp, stoResp.StatusCode, apiResp, enc)
+	respCode = stoResp.StatusCode
+	apiResp = apiResponse{stoResp.Err, "", nil}
 	return
 }
 

--- a/noauthapimethods.go
+++ b/noauthapimethods.go
@@ -31,17 +31,29 @@ func crudMarshall(resp http.ResponseWriter, respCode int, apiResp apiResponse, e
 	return
 }
 
-func (self NoAuthApiMethods) CreateOne(resp http.ResponseWriter, req *http.Request) {
-	//read request
-	vars, enc, dec := crudUnmarshall(resp, req)
-	//perform the action
-	respCode, apiResp := self.CreateOnePerform(vars, dec)
-	//write response
-	crudMarshall(resp, respCode, apiResp, enc)
+func (self NoAuthApiMethods) CrudCall(crudMethod func(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)) (httpMethod func(resp http.ResponseWriter, req *http.Request)) {
+	httpMethod = func(resp http.ResponseWriter, req *http.Request) {
+		//read request
+		vars, enc, dec := crudUnmarshall(resp, req)
+		//perform the action
+		respCode, apiResp := crudMethod(vars, dec)
+		//write response
+		crudMarshall(resp, respCode, apiResp, enc)
+	}
 	return
 }
 
-func (self NoAuthApiMethods) CreateOnePerform(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
+// func (self NoAuthApiMethods) CreateOne(resp http.ResponseWriter, req *http.Request) {
+// 	//read request
+// 	vars, enc, dec := crudUnmarshall(resp, req)
+// 	//perform the action
+// 	respCode, apiResp := self.CreateOnePerform(vars, dec)
+// 	//write response
+// 	crudMarshall(resp, respCode, apiResp, enc)
+// 	return
+// }
+
+func (self NoAuthApiMethods) CreateOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 
 	// read body and parse into interface{}
@@ -61,17 +73,17 @@ func (self NoAuthApiMethods) CreateOnePerform(vars map[string]string, dec *json.
 	return
 }
 
-func (self NoAuthApiMethods) ReadOne(resp http.ResponseWriter, req *http.Request) {
-	//read request
-	vars, enc, dec := crudUnmarshall(resp, req)
-	//perform the action
-	respCode, apiResp := self.ReadOnePerform(vars, dec)
-	//write response
-	crudMarshall(resp, respCode, apiResp, enc)
-	return
-}
+// func (self NoAuthApiMethods) ReadOne(resp http.ResponseWriter, req *http.Request) {
+// 	//read request
+// 	vars, enc, dec := crudUnmarshall(resp, req)
+// 	//perform the action
+// 	respCode, apiResp := self.ReadOnePerform(vars, dec)
+// 	//write response
+// 	crudMarshall(resp, respCode, apiResp, enc)
+// 	return
+// }
 
-func (self NoAuthApiMethods) ReadOnePerform(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
+func (self NoAuthApiMethods) ReadOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 	id := vars["id"]
 
@@ -82,17 +94,17 @@ func (self NoAuthApiMethods) ReadOnePerform(vars map[string]string, dec *json.De
 	return
 }
 
-func (self NoAuthApiMethods) ReadAll(resp http.ResponseWriter, req *http.Request) {
-	//read request
-	vars, enc, dec := crudUnmarshall(resp, req)
-	//perform the action
-	respCode, apiResp := self.ReadAllPerform(vars, dec)
-	//write response
-	crudMarshall(resp, respCode, apiResp, enc)
-	return
-}
+// func (self NoAuthApiMethods) ReadAll(resp http.ResponseWriter, req *http.Request) {
+// 	//read request
+// 	vars, enc, dec := crudUnmarshall(resp, req)
+// 	//perform the action
+// 	respCode, apiResp := self.ReadAllPerform(vars, dec)
+// 	//write response
+// 	crudMarshall(resp, respCode, apiResp, enc)
+// 	return
+// }
 
-func (self NoAuthApiMethods) ReadAllPerform(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
+func (self NoAuthApiMethods) ReadAll(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 
 	// look for resources
@@ -102,17 +114,17 @@ func (self NoAuthApiMethods) ReadAllPerform(vars map[string]string, dec *json.De
 	return
 }
 
-func (self NoAuthApiMethods) UpdateOne(resp http.ResponseWriter, req *http.Request) {
-	//read request
-	vars, enc, dec := crudUnmarshall(resp, req)
-	//perform the action
-	respCode, apiResp := self.UpdateOnePerform(vars, dec)
-	//write response
-	crudMarshall(resp, respCode, apiResp, enc)
-	return
-}
+// func (self NoAuthApiMethods) UpdateOne(resp http.ResponseWriter, req *http.Request) {
+// 	//read request
+// 	vars, enc, dec := crudUnmarshall(resp, req)
+// 	//perform the action
+// 	respCode, apiResp := self.UpdateOnePerform(vars, dec)
+// 	//write response
+// 	crudMarshall(resp, respCode, apiResp, enc)
+// 	return
+// }
 
-func (self NoAuthApiMethods) UpdateOnePerform(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
+func (self NoAuthApiMethods) UpdateOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 	id := vars["id"]
 
@@ -133,17 +145,17 @@ func (self NoAuthApiMethods) UpdateOnePerform(vars map[string]string, dec *json.
 	return
 }
 
-func (self NoAuthApiMethods) DeleteOne(resp http.ResponseWriter, req *http.Request) {
-	//read request
-	vars, enc, dec := crudUnmarshall(resp, req)
-	//perform the action
-	respCode, apiResp := self.DeleteOnePerform(vars, dec)
-	//write response
-	crudMarshall(resp, respCode, apiResp, enc)
-	return
-}
+// func (self NoAuthApiMethods) DeleteOne(resp http.ResponseWriter, req *http.Request) {
+// 	//read request
+// 	vars, enc, dec := crudUnmarshall(resp, req)
+// 	//perform the action
+// 	respCode, apiResp := self.DeleteOnePerform(vars, dec)
+// 	//write response
+// 	crudMarshall(resp, respCode, apiResp, enc)
+// 	return
+// }
 
-func (self NoAuthApiMethods) DeleteOnePerform(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
+func (self NoAuthApiMethods) DeleteOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 	id := vars["id"]
 
@@ -154,17 +166,17 @@ func (self NoAuthApiMethods) DeleteOnePerform(vars map[string]string, dec *json.
 	return
 }
 
-func (self NoAuthApiMethods) DeleteAll(resp http.ResponseWriter, req *http.Request) {
-	//read request
-	vars, enc, dec := crudUnmarshall(resp, req)
-	//perform the action
-	respCode, apiResp := self.DeleteAllPerform(vars, dec)
-	//write response
-	crudMarshall(resp, respCode, apiResp, enc)
-	return
-}
+// func (self NoAuthApiMethods) DeleteAll(resp http.ResponseWriter, req *http.Request) {
+// 	//read request
+// 	vars, enc, dec := crudUnmarshall(resp, req)
+// 	//perform the action
+// 	respCode, apiResp := self.DeleteAllPerform(vars, dec)
+// 	//write response
+// 	crudMarshall(resp, respCode, apiResp, enc)
+// 	return
+// }
 
-func (self NoAuthApiMethods) DeleteAllPerform(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
+func (self NoAuthApiMethods) DeleteAll(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {
 	kind := vars["kind"]
 
 	// look for resources

--- a/noauthapimethods.go
+++ b/noauthapimethods.go
@@ -24,9 +24,6 @@ func crudUnmarshall(resp http.ResponseWriter, req *http.Request) (vars map[strin
 
 func (self NoAuthApiMethods) CreateOne(resp http.ResponseWriter, req *http.Request) {
   vars, enc, dec := crudUnmarshall(resp, req)
-  // vars := mux.Vars(req)
-  // enc := json.NewEncoder(resp)
-  // dec := json.NewDecoder(req.Body)
   kind := vars["kind"]
 
   // read body and parse into interface{}
@@ -58,10 +55,9 @@ func (self NoAuthApiMethods) CreateOne(resp http.ResponseWriter, req *http.Reque
 }
 
 func (self NoAuthApiMethods) ReadOne(resp http.ResponseWriter, req *http.Request) {
-  vars := mux.Vars(req)
+  vars, enc, _ := crudUnmarshall(resp, req)
   kind := vars["kind"]
   id := vars["id"]
-  enc := json.NewEncoder(resp)
 
   // look for resource
   resource, stoResp := self.s.Get(kind, id)
@@ -75,10 +71,9 @@ func (self NoAuthApiMethods) ReadOne(resp http.ResponseWriter, req *http.Request
   return
 }
 
-func (self NoAuthApiMethods) ReadAll(resp http.ResponseWriter, req *http.Request) {
-  vars := mux.Vars(req)
+func (self NoAuthApiMethods) ReadAll(resp http.ResponseWriter, req *http.Request) {  
+  vars, enc, _ := crudUnmarshall(resp, req)
   kind := vars["kind"]
-  enc := json.NewEncoder(resp)
 
   // look for resources
   resources, stoResp := self.s.GetAll(kind)
@@ -93,11 +88,9 @@ func (self NoAuthApiMethods) ReadAll(resp http.ResponseWriter, req *http.Request
 }
 
 func (self NoAuthApiMethods) UpdateOne(resp http.ResponseWriter, req *http.Request) {
-  vars := mux.Vars(req)
+  vars, enc, dec := crudUnmarshall(resp, req)
   kind := vars["kind"]
   id := vars["id"]
-  enc := json.NewEncoder(resp)
-  dec := json.NewDecoder(req.Body)
 
   // read body and parse into interface{}
   var resource map[string]interface{}
@@ -127,10 +120,9 @@ func (self NoAuthApiMethods) UpdateOne(resp http.ResponseWriter, req *http.Reque
 }
 
 func (self NoAuthApiMethods) DeleteOne(resp http.ResponseWriter, req *http.Request) {
-  vars := mux.Vars(req)
+  vars, enc, _ := crudUnmarshall(resp, req)
   kind := vars["kind"]
   id := vars["id"]
-  enc := json.NewEncoder(resp)
 
   // delete resource
   stoResp := self.s.Delete(kind, id)
@@ -145,9 +137,8 @@ func (self NoAuthApiMethods) DeleteOne(resp http.ResponseWriter, req *http.Reque
 }
 
 func (self NoAuthApiMethods) DeleteAll(resp http.ResponseWriter, req *http.Request) {
-  vars := mux.Vars(req)
+  vars, enc, _ := crudUnmarshall(resp, req)
   kind := vars["kind"]
-  enc := json.NewEncoder(resp)
 
   // look for resources
   stoResp := self.s.DeleteAll(kind)

--- a/noauthapimethods.go
+++ b/noauthapimethods.go
@@ -15,11 +15,19 @@ func NewNoAuthApiMethods(store Storage) NoAuthApiMethods {
   return NoAuthApiMethods{store}
 }
 
+func crudUnmarshall(resp http.ResponseWriter, req *http.Request) (vars map[string]string, enc *json.Encoder, dec *json.Decoder) {
+  vars = mux.Vars(req)
+  enc = json.NewEncoder(resp)
+  dec = json.NewDecoder(req.Body)
+  return
+}
+
 func (self NoAuthApiMethods) CreateOne(resp http.ResponseWriter, req *http.Request) {
-  vars := mux.Vars(req)
+  vars, enc, dec := crudUnmarshall(resp, req)
+  // vars := mux.Vars(req)
+  // enc := json.NewEncoder(resp)
+  // dec := json.NewDecoder(req.Body)
   kind := vars["kind"]
-  enc := json.NewEncoder(resp)
-  dec := json.NewDecoder(req.Body)
 
   // read body and parse into interface{}
   var resource map[string]interface{}

--- a/noauthapimethods.go
+++ b/noauthapimethods.go
@@ -22,13 +22,13 @@ func crudUnmarshall(resp http.ResponseWriter, req *http.Request) (vars map[strin
 }
 
 func crudMarshall(resp http.ResponseWriter, stoResp StorageResponse, apiResp apiResponse, enc *json.Encoder) {
-  resp.WriteHeader(stoResp.StatusCode)
-  enc = json.NewEncoder(resp)
-  err := enc.Encode(apiResp)
-  if err != nil {
-    log.Println(err)
-  }
-  return
+	resp.WriteHeader(stoResp.StatusCode)
+	enc = json.NewEncoder(resp)
+	err := enc.Encode(apiResp)
+	if err != nil {
+		log.Println(err)
+	}
+	return
 }
 
 func (self NoAuthApiMethods) CreateOne(resp http.ResponseWriter, req *http.Request) {
@@ -53,15 +53,10 @@ func (self NoAuthApiMethods) CreateOne(resp http.ResponseWriter, req *http.Reque
 
 	// set in storage
 	id, stoResp := self.s.Create(kind, resource)
-  apiResp := apiResponse{stoResp.Err, id, nil}
+	apiResp := apiResponse{stoResp.Err, id, nil}
 
 	// write response
-  crudMarshall(resp, stoResp, apiResp, enc)
-	// resp.WriteHeader(stoResp.StatusCode)
-	// err = enc.Encode()
-	// if err != nil {
-	// 	log.Println(err)
-	// }
+	crudMarshall(resp, stoResp, apiResp, enc)
 	return
 }
 
@@ -72,15 +67,10 @@ func (self NoAuthApiMethods) ReadOne(resp http.ResponseWriter, req *http.Request
 
 	// look for resource
 	resource, stoResp := self.s.Get(kind, id)
-  apiResp := apiResponse{stoResp.Err, "", resource}
+	apiResp := apiResponse{stoResp.Err, "", resource}
 
 	// write response
-  crudMarshall(resp, stoResp, apiResp, enc)
-	// resp.WriteHeader(stoResp.StatusCode)
-	// err := enc.Encode()
-	// if err != nil {
-	// 	log.Println(err)
-	// }
+	crudMarshall(resp, stoResp, apiResp, enc)
 	return
 }
 
@@ -90,15 +80,10 @@ func (self NoAuthApiMethods) ReadAll(resp http.ResponseWriter, req *http.Request
 
 	// look for resources
 	resources, stoResp := self.s.GetAll(kind)
-  apiResp := apiResponse{stoResp.Err, "", resources}
+	apiResp := apiResponse{stoResp.Err, "", resources}
 
 	// write response
-  crudMarshall(resp, stoResp, apiResp, enc)
-  // resp.WriteHeader(stoResp.StatusCode)
-	// err := enc.Encode()
-	// if err != nil {
-	// 	log.Println(err)
-	// }
+	crudMarshall(resp, stoResp, apiResp, enc)
 	return
 }
 
@@ -124,15 +109,10 @@ func (self NoAuthApiMethods) UpdateOne(resp http.ResponseWriter, req *http.Reque
 
 	// update resource
 	stoResp := self.s.Update(kind, id, resource)
-  apiResp := apiResponse{stoResp.Err, "", nil}
+	apiResp := apiResponse{stoResp.Err, "", nil}
 
 	// write response
-  crudMarshall(resp, stoResp, apiResp, enc)
-	// resp.WriteHeader(stoResp.StatusCode)
-	// err = enc.Encode()
-	// if err != nil {
-	// 	log.Println(err)
-	// }
+	crudMarshall(resp, stoResp, apiResp, enc)
 	return
 }
 
@@ -143,15 +123,10 @@ func (self NoAuthApiMethods) DeleteOne(resp http.ResponseWriter, req *http.Reque
 
 	// delete resource
 	stoResp := self.s.Delete(kind, id)
-  apiResp := apiResponse{stoResp.Err, "", nil}
+	apiResp := apiResponse{stoResp.Err, "", nil}
 
 	// write response
-  crudMarshall(resp, stoResp, apiResp, enc)
-	// resp.WriteHeader(stoResp.StatusCode)
-	// err := enc.Encode()
-	// if err != nil {
-	// 	log.Println(err)
-	// }
+	crudMarshall(resp, stoResp, apiResp, enc)
 	return
 }
 
@@ -161,15 +136,10 @@ func (self NoAuthApiMethods) DeleteAll(resp http.ResponseWriter, req *http.Reque
 
 	// look for resources
 	stoResp := self.s.DeleteAll(kind)
-  apiResp := apiResponse{stoResp.Err, "", nil}
+	apiResp := apiResponse{stoResp.Err, "", nil}
 
 	// write response
-  crudMarshall(resp, stoResp, apiResp, enc)
-	// resp.WriteHeader(stoResp.StatusCode)
-	// err := enc.Encode()
-	// if err != nil {
-	// 	log.Println(err)
-	// }
+	crudMarshall(resp, stoResp, apiResp, enc)
 	return
 }
 

--- a/noauthapimethods.go
+++ b/noauthapimethods.go
@@ -1,0 +1,44 @@
+package crudapi
+
+import (
+  "encoding/json"
+  "github.com/gorilla/mux"
+  "log"
+  "net/http"
+)
+
+type NoAuthApiMethods struct {
+  s Storage
+}
+
+func NewNoAuthApiMethods(store Storage) NoAuthApiMethods {
+  return NoAuthApiMethods{store}
+}
+
+func (self NoAuthApiMethods) CreateOne(resp http.ResponseWriter, req *http.Request) {
+}
+
+func (self NoAuthApiMethods) ReadOne(resp http.ResponseWriter, req *http.Request) {
+  return
+}
+func (self NoAuthApiMethods) ReadAll(resp http.ResponseWriter, req *http.Request) {
+  return
+}
+
+func (self NoAuthApiMethods) UpdateOne(resp http.ResponseWriter, req *http.Request) {
+  return
+}
+
+func (self NoAuthApiMethods) DeleteOne(resp http.ResponseWriter, req *http.Request) {
+  return
+}
+func (self NoAuthApiMethods) DeleteAll(resp http.ResponseWriter, req *http.Request) {
+  return
+}
+
+func (self NoAuthApiMethods) OptionsOne(resp http.ResponseWriter, req *http.Request) {
+  return
+}
+func (self NoAuthApiMethods) OptionsAll(resp http.ResponseWriter, req *http.Request) {
+  return
+}

--- a/noauthapimethods.go
+++ b/noauthapimethods.go
@@ -1,176 +1,197 @@
 package crudapi
 
 import (
-  "encoding/json"
-  "github.com/gorilla/mux"
-  "log"
-  "net/http"
+	"encoding/json"
+	"github.com/gorilla/mux"
+	"log"
+	"net/http"
 )
 
 type NoAuthApiMethods struct {
-  s Storage
+	s Storage
 }
 
 func NewNoAuthApiMethods(store Storage) NoAuthApiMethods {
-  return NoAuthApiMethods{store}
+	return NoAuthApiMethods{store}
 }
 
 func crudUnmarshall(resp http.ResponseWriter, req *http.Request) (vars map[string]string, enc *json.Encoder, dec *json.Decoder) {
-  vars = mux.Vars(req)
+	vars = mux.Vars(req)
+	dec = json.NewDecoder(req.Body)
+	return
+}
+
+func crudMarshall(resp http.ResponseWriter, stoResp StorageResponse, apiResp apiResponse, enc *json.Encoder) {
+  resp.WriteHeader(stoResp.StatusCode)
   enc = json.NewEncoder(resp)
-  dec = json.NewDecoder(req.Body)
+  err := enc.Encode(apiResp)
+  if err != nil {
+    log.Println(err)
+  }
   return
 }
 
 func (self NoAuthApiMethods) CreateOne(resp http.ResponseWriter, req *http.Request) {
-  vars, enc, dec := crudUnmarshall(resp, req)
-  kind := vars["kind"]
+	vars, enc, dec := crudUnmarshall(resp, req)
+	kind := vars["kind"]
 
-  // read body and parse into interface{}
-  var resource map[string]interface{}
-  err := dec.Decode(&resource)
+	// read body and parse into interface{}
+	var resource map[string]interface{}
+	err := dec.Decode(&resource)
 
-  if err != nil {
-   log.Println(err)
+	if err != nil {
+		log.Println(err)
 
-   resp.WriteHeader(http.StatusBadRequest)
-   err = enc.Encode(apiResponse{"malformed json", "", nil})
-   if err != nil {
-     log.Println(err)
-   }
+		resp.WriteHeader(http.StatusBadRequest)
+		err = enc.Encode(apiResponse{"malformed json", "", nil})
+		if err != nil {
+			log.Println(err)
+		}
 
-   return
-  }
+		return
+	}
 
-  // set in storage
-  id, stoResp := self.s.Create(kind, resource)
+	// set in storage
+	id, stoResp := self.s.Create(kind, resource)
+  apiResp := apiResponse{stoResp.Err, id, nil}
 
-  // write response
-  resp.WriteHeader(stoResp.StatusCode)
-  err = enc.Encode(apiResponse{stoResp.Err, id, nil})
-  if err != nil {
-   log.Println(err)
-  }
-  return
+	// write response
+  crudMarshall(resp, stoResp, apiResp, enc)
+	// resp.WriteHeader(stoResp.StatusCode)
+	// err = enc.Encode()
+	// if err != nil {
+	// 	log.Println(err)
+	// }
+	return
 }
 
 func (self NoAuthApiMethods) ReadOne(resp http.ResponseWriter, req *http.Request) {
-  vars, enc, _ := crudUnmarshall(resp, req)
-  kind := vars["kind"]
-  id := vars["id"]
+	vars, enc, _ := crudUnmarshall(resp, req)
+	kind := vars["kind"]
+	id := vars["id"]
 
-  // look for resource
-  resource, stoResp := self.s.Get(kind, id)
+	// look for resource
+	resource, stoResp := self.s.Get(kind, id)
+  apiResp := apiResponse{stoResp.Err, "", resource}
 
-  // write response
-  resp.WriteHeader(stoResp.StatusCode)
-  err := enc.Encode(apiResponse{stoResp.Err, "", resource})
-  if err != nil {
-   log.Println(err)
-  }
-  return
+	// write response
+  crudMarshall(resp, stoResp, apiResp, enc)
+	// resp.WriteHeader(stoResp.StatusCode)
+	// err := enc.Encode()
+	// if err != nil {
+	// 	log.Println(err)
+	// }
+	return
 }
 
-func (self NoAuthApiMethods) ReadAll(resp http.ResponseWriter, req *http.Request) {  
-  vars, enc, _ := crudUnmarshall(resp, req)
-  kind := vars["kind"]
+func (self NoAuthApiMethods) ReadAll(resp http.ResponseWriter, req *http.Request) {
+	vars, enc, _ := crudUnmarshall(resp, req)
+	kind := vars["kind"]
 
-  // look for resources
-  resources, stoResp := self.s.GetAll(kind)
+	// look for resources
+	resources, stoResp := self.s.GetAll(kind)
+  apiResp := apiResponse{stoResp.Err, "", resources}
 
-  // write response
-  resp.WriteHeader(stoResp.StatusCode)
-  err := enc.Encode(apiResponse{stoResp.Err, "", resources})
-  if err != nil {
-   log.Println(err)
-  }
-  return
+	// write response
+  crudMarshall(resp, stoResp, apiResp, enc)
+  // resp.WriteHeader(stoResp.StatusCode)
+	// err := enc.Encode()
+	// if err != nil {
+	// 	log.Println(err)
+	// }
+	return
 }
 
 func (self NoAuthApiMethods) UpdateOne(resp http.ResponseWriter, req *http.Request) {
-  vars, enc, dec := crudUnmarshall(resp, req)
-  kind := vars["kind"]
-  id := vars["id"]
+	vars, enc, dec := crudUnmarshall(resp, req)
+	kind := vars["kind"]
+	id := vars["id"]
 
-  // read body and parse into interface{}
-  var resource map[string]interface{}
-  err := dec.Decode(&resource)
+	// read body and parse into interface{}
+	var resource map[string]interface{}
+	err := dec.Decode(&resource)
 
-  if err != nil {
-   log.Println(err)
-   resp.WriteHeader(http.StatusBadRequest)
-   err = enc.Encode(apiResponse{"malformed json", "", nil})
-   if err != nil {
-     log.Println(err)
-   }
+	if err != nil {
+		log.Println(err)
+		resp.WriteHeader(http.StatusBadRequest)
+		err = enc.Encode(apiResponse{"malformed json", "", nil})
+		if err != nil {
+			log.Println(err)
+		}
 
-   return
-  }
+		return
+	}
 
-  // update resource
-  stoResp := self.s.Update(kind, id, resource)
+	// update resource
+	stoResp := self.s.Update(kind, id, resource)
+  apiResp := apiResponse{stoResp.Err, "", nil}
 
-  // write response
-  resp.WriteHeader(stoResp.StatusCode)
-  err = enc.Encode(apiResponse{stoResp.Err, "", nil})
-  if err != nil {
-   log.Println(err)
-  }
-  return
+	// write response
+  crudMarshall(resp, stoResp, apiResp, enc)
+	// resp.WriteHeader(stoResp.StatusCode)
+	// err = enc.Encode()
+	// if err != nil {
+	// 	log.Println(err)
+	// }
+	return
 }
 
 func (self NoAuthApiMethods) DeleteOne(resp http.ResponseWriter, req *http.Request) {
-  vars, enc, _ := crudUnmarshall(resp, req)
-  kind := vars["kind"]
-  id := vars["id"]
+	vars, enc, _ := crudUnmarshall(resp, req)
+	kind := vars["kind"]
+	id := vars["id"]
 
-  // delete resource
-  stoResp := self.s.Delete(kind, id)
+	// delete resource
+	stoResp := self.s.Delete(kind, id)
+  apiResp := apiResponse{stoResp.Err, "", nil}
 
-  // write response
-  resp.WriteHeader(stoResp.StatusCode)
-  err := enc.Encode(apiResponse{stoResp.Err, "", nil})
-  if err != nil {
-   log.Println(err)
-  }
-  return
+	// write response
+  crudMarshall(resp, stoResp, apiResp, enc)
+	// resp.WriteHeader(stoResp.StatusCode)
+	// err := enc.Encode()
+	// if err != nil {
+	// 	log.Println(err)
+	// }
+	return
 }
 
 func (self NoAuthApiMethods) DeleteAll(resp http.ResponseWriter, req *http.Request) {
-  vars, enc, _ := crudUnmarshall(resp, req)
-  kind := vars["kind"]
+	vars, enc, _ := crudUnmarshall(resp, req)
+	kind := vars["kind"]
 
-  // look for resources
-  stoResp := self.s.DeleteAll(kind)
+	// look for resources
+	stoResp := self.s.DeleteAll(kind)
+  apiResp := apiResponse{stoResp.Err, "", nil}
 
-  // write response
-  resp.WriteHeader(stoResp.StatusCode)
-  err := enc.Encode(apiResponse{stoResp.Err, "", nil})
-  if err != nil {
-   log.Println(err)
-  }
-  return
+	// write response
+  crudMarshall(resp, stoResp, apiResp, enc)
+	// resp.WriteHeader(stoResp.StatusCode)
+	// err := enc.Encode()
+	// if err != nil {
+	// 	log.Println(err)
+	// }
+	return
 }
 
 func (self NoAuthApiMethods) OptionsOne(resp http.ResponseWriter, req *http.Request) {
-  h := resp.Header()
+	h := resp.Header()
 
-  h.Add("Allow", "PUT")
-  h.Add("Allow", "GET")
-  h.Add("Allow", "DELETE")
-  h.Add("Allow", "OPTIONS")
+	h.Add("Allow", "PUT")
+	h.Add("Allow", "GET")
+	h.Add("Allow", "DELETE")
+	h.Add("Allow", "OPTIONS")
 
-  resp.WriteHeader(http.StatusOK)
-  return
+	resp.WriteHeader(http.StatusOK)
+	return
 }
 func (self NoAuthApiMethods) OptionsAll(resp http.ResponseWriter, req *http.Request) {
-  h := resp.Header()
+	h := resp.Header()
 
-  h.Add("Allow", "POST")
-  h.Add("Allow", "GET")
-  h.Add("Allow", "DELETE")
-  h.Add("Allow", "OPTIONS")
+	h.Add("Allow", "POST")
+	h.Add("Allow", "GET")
+	h.Add("Allow", "DELETE")
+	h.Add("Allow", "OPTIONS")
 
-  resp.WriteHeader(http.StatusOK)
-  return
+	resp.WriteHeader(http.StatusOK)
+	return
 }

--- a/noauthapimethods.go
+++ b/noauthapimethods.go
@@ -2,7 +2,6 @@ package crudapi
 
 import (
 	"encoding/json"
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 )
@@ -13,34 +12,6 @@ type NoAuthApiMethods struct {
 
 func NewNoAuthApiMethods(store Storage) NoAuthApiMethods {
 	return NoAuthApiMethods{store}
-}
-
-func crudUnmarshall(resp http.ResponseWriter, req *http.Request) (vars map[string]string, enc *json.Encoder, dec *json.Decoder) {
-	vars = mux.Vars(req)
-	dec = json.NewDecoder(req.Body)
-	return
-}
-
-func crudMarshall(resp http.ResponseWriter, respCode int, apiResp apiResponse, enc *json.Encoder) {
-	resp.WriteHeader(respCode)
-	enc = json.NewEncoder(resp)
-	err := enc.Encode(apiResp)
-	if err != nil {
-		log.Println(err)
-	}
-	return
-}
-
-func (self NoAuthApiMethods) CrudCall(crudMethod func(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse)) (httpMethod func(resp http.ResponseWriter, req *http.Request)) {
-	httpMethod = func(resp http.ResponseWriter, req *http.Request) {
-		//read request
-		vars, enc, dec := crudUnmarshall(resp, req)
-		//perform the action
-		respCode, apiResp := crudMethod(vars, dec)
-		//write response
-		crudMarshall(resp, respCode, apiResp, enc)
-	}
-	return
 }
 
 func (self NoAuthApiMethods) CreateOne(vars map[string]string, dec *json.Decoder) (respCode int, apiResp apiResponse) {


### PR DESCRIPTION
Simple change here - simply defined an interface for the API methods.

Currently there is only one possible implementation for this, the one given. This would allow the client to define their own implementations for the API.

One idea that I toyed with, and I have been sitting on the fence about is whether the interface should necessitate a Storage object. In the end I leaned toward flexibility, and let the implementor decide.

Cheers!
